### PR TITLE
Only run the `todo-actions` on master

### DIFF
--- a/.github/workflows/push-process-todo-comments.yml
+++ b/.github/workflows/push-process-todo-comments.yml
@@ -1,4 +1,7 @@
-on: push
+on:
+  push:
+    branches:
+      - master
 name: Process TODO comments
 jobs:
   collectTODO:


### PR DESCRIPTION
Previously `todo-actions` would abort the work if it detects that is not running in the master branch. However the GitHub environment has changed and broke this logic. Fortunately, this update also allows us to configure in the workflow yaml file which branch to run.

The first step is to disable running `todo-actions` on other branches except `master`.